### PR TITLE
Changed permission for editing of soft and hardware settings

### DIFF
--- a/src/menus/ServerActionsMenu.php
+++ b/src/menus/ServerActionsMenu.php
@@ -84,7 +84,7 @@ class ServerActionsMenu extends \hiqdev\yii2\menus\Menu
             ],
             'hardware-settings' => [
                 'label' => Yii::t('hipanel:server', 'Hardware properties'),
-                'visible' => $user->can('support'),
+                'visible' => $user->can('server.manage-settings'),
                 'icon' => 'fa-cogs',
                 'url' => ['@server/hardware-settings', 'id' => $this->model->id],
                 'linkOptions' => [
@@ -94,7 +94,7 @@ class ServerActionsMenu extends \hiqdev\yii2\menus\Menu
             ],
             'software-settings' => [
                 'label' => Yii::t('hipanel:server', 'Software properties'),
-                'visible' => $user->can('support'),
+                'visible' => $user->can('server.manage-settings'),
                 'icon' => 'fa-cogs',
                 'url' => ['@server/software-settings', 'id' => $this->model->id],
                 'linkOptions' => [

--- a/src/models/query/ServerQuery.php
+++ b/src/models/query/ServerQuery.php
@@ -53,7 +53,7 @@ class ServerQuery extends ActiveQuery
 
     public function withSoftwareSettings(): self
     {
-        if (Yii::$app->user->can('admin')) {
+        if (Yii::$app->user->can('server.manage-settings')) {
             $this->joinWith(['softwareSettings']);
             $this->andWhere(['with_softwareSettings' => 1]);
         }


### PR DESCRIPTION
The editing of software setting looked like broken, because
user had not permission to read actual software settings.
So, user was able to change settings, but not read it.

trello card: https://trello.com/c/2zXk14Aw