### PR TITLE
HP-2045: Add links to IPMI and Nic2 devices on the Server view page

### DIFF
--- a/src/grid/BindingColumn.php
+++ b/src/grid/BindingColumn.php
@@ -22,6 +22,12 @@ class BindingColumn extends DataColumn
 
     public $filter = false;
 
+    public $encodeLabel = false;
+
+    public ?string $serverName = null;
+
+    public ?int $deviceId = null;
+
     public function init()
     {
         parent::init();
@@ -66,8 +72,19 @@ class BindingColumn extends DataColumn
     {
         $defaultLabel = $this->getHeaderCellLabel();
         $addColon = preg_replace('/(\d+)/', ':${1}', $defaultLabel);
-        $replaceName = preg_replace(['/Net/', '/Pdu/'], ['Switch', 'APC'], $addColon);
+        $label = (string)preg_replace(['/Net/', '/Pdu/'], ['Switch', 'APC'], $addColon);
 
-        return (string) $replaceName;
+        return $label . $this->getIpmiOrNic2LinkToLabel($this->attribute, $this->deviceId, $this->serverName);
+    }
+
+    private function getIpmiOrNic2LinkToLabel(string $type, ?int $deviceId, ?string $serverName = null): string
+    {
+        $link = '';
+        if ($type === 'ipmi' && $deviceId && $serverName) {
+            $link = '<br/>' . Html::a($serverName . $type, ['@hub/view', 'id' => $deviceId]);
+        } elseif ($type === 'net2' && $deviceId && $serverName) {
+            $link = '<br/>' . Html::a($serverName . $type, ['@server/view', 'id' => $deviceId]);
+        }
+        return $link;
     }
 }

--- a/src/models/Binding.php
+++ b/src/models/Binding.php
@@ -22,7 +22,7 @@ class Binding extends \hipanel\base\Model
     public function rules()
     {
         return [
-            [['device_id', 'switch_id', 'no', 'base_device_id'], 'integer'],
+            [['device_id', 'switch_id', 'no', 'base_device_id', 'obj_id'], 'integer'],
             [
                 [
                     'switch_name', 'device_name', 'base_device_name', 'port', 'type', 'switch', 'switch_label',

--- a/src/views/server/view.php
+++ b/src/views/server/view.php
@@ -386,11 +386,13 @@ if ($model->running_task) {
                         <?= ServerGridView::detailView([
                             'model' => $model,
                             'boxed' => false,
-                            'columns' => array_map(function ($binding) {
+                            'columns' => array_map(function ($binding) use ($model) {
                                 /** @var Binding $binding */
                                 return [
                                     'class' => BindingColumn::class,
                                     'attribute' => $binding->typeWithNo,
+                                    'serverName' => $model->name,
+                                    'deviceId' => $binding->obj_id,
                                 ];
                             }, $model->bindings),
                         ]) ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `serverName` and `deviceId` properties to enhance server and device identification.
  
- **Bug Fixes**
  - Included `'obj_id'` in integer attributes list to ensure correct data type validation.
  
- **Improvements**
  - Improved labeling by appending conditional links to enhance user navigation.
  
- **UI Enhancements**
  - Displayed `serverName` and `deviceId` in server views for better visibility and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->