### PR TITLE
HP-2061: device name limit for DNS resolving

### DIFF
--- a/src/forms/ServerForm.php
+++ b/src/forms/ServerForm.php
@@ -56,6 +56,7 @@ class ServerForm extends Server
         return array_merge(parent::rules(), [
             // Create/update servers
             [['server', 'type', 'state'], 'required', 'on' => ['create', 'update']],
+            [['server', 'new_server_name'], 'string', 'max' => 63, 'min' => 1],
             [['new_server_name'], 'required', 'on' => 'update'],
             [['server', 'dc'], 'unique', 'on' => ['create']],
             [

--- a/src/models/Hub.php
+++ b/src/models/Hub.php
@@ -54,6 +54,7 @@ class Hub extends Model implements AssignSwitchInterface, TaggableInterface
                 'oob_key', 'traf_server_id_label', 'vlan_server_id_label', 'type', 'server_type', 'state', 'state_label',
                 'stat_device', 'stat_domain',
             ], 'string'],
+            [['name'], 'string', 'min' => 1, 'max' => 63],
             [['virtual'], 'boolean'],
 
             [['tariff_id', 'sale_time'], 'required', 'on' => ['sale']],

--- a/src/models/Server.php
+++ b/src/models/Server.php
@@ -65,6 +65,7 @@ class Server extends Model implements AssignSwitchInterface, TaggableInterface
             [['id', 'tariff_id', 'client_id', 'seller_id', 'mails_num'], 'integer'],
             [['osimage'], EidValidator::class],
             [['panel'], RefValidator::class],
+            [['name'], 'string', 'min' => 1, 'max' => 63],
             [
                 [
                     'name', 'dc',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for `new_server_name` to ensure it is a string between 1 and 63 characters, improving integrity during server updates.
	- Added validation for `name` attribute in the Hub and Server sections, enforcing a minimum length of 1 and maximum length of 63 characters for better data quality.

- **Bug Fixes**
	- Improved data integrity checks for the `name` fields across models, reducing potential issues with invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->