### PR TITLE
HP-2196: add consumption for both, hub and server modules

### DIFF
--- a/src/models/ConsumptionSearchAttributes.php
+++ b/src/models/ConsumptionSearchAttributes.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace hipanel\modules\server\models;
+
+use Yii;
+
+trait ConsumptionSearchAttributes
+{
+    public function consumptionSearchRules(): array
+    {
+        return [
+            [['uses_month'], 'match', 'pattern' => '/^[A-Z][a-z]{2} \d{4}$/'],
+        ];
+    }
+
+    public function consumptionAttributes(): array
+    {
+        return ['uses_month'];
+    }
+
+    public function consumptionAttributeLabels(): array
+    {
+        return [
+            'uses_month' => Yii::t('hipanel:server', 'Consumption for {0}'),
+        ];
+    }
+}

--- a/src/models/Hub.php
+++ b/src/models/Hub.php
@@ -13,7 +13,6 @@ namespace hipanel\modules\server\models;
 use hipanel\base\Model;
 use hipanel\base\ModelTrait;
 use hipanel\behaviors\TaggableBehavior;
-use hipanel\models\Ref;
 use hipanel\models\TaggableInterface;
 use hipanel\modules\finance\models\proxy\Resource;
 use hipanel\modules\server\models\query\HubQuery;

--- a/src/models/HubSearch.php
+++ b/src/models/HubSearch.php
@@ -16,8 +16,9 @@ use Yii;
 
 class HubSearch extends Hub
 {
-    use SearchModelTrait {
+    use ConsumptionSearchAttributes, SearchModelTrait {
         searchAttributes as defaultSearchAttributes;
+        rules as defaultSearchRules;
     }
 
     public static function tableName()
@@ -25,12 +26,17 @@ class HubSearch extends Hub
         return Hub::tableName();
     }
 
+    public function rules()
+    {
+        return array_merge($this->defaultSearchRules(), $this->consumptionSearchRules());
+    }
+
     /**
      * {@inheritdoc}
      */
     public function searchAttributes()
     {
-        return ArrayHelper::merge($this->defaultSearchAttributes(), [
+        return ArrayHelper::merge($this->defaultSearchAttributes(), $this->consumptionAttributes(), [
             'show_deleted',
             'with_bindings',
             'with_servers',
@@ -45,7 +51,7 @@ class HubSearch extends Hub
 
     public function attributeLabels()
     {
-        return array_merge(parent::attributeLabels(), [
+        return array_merge(parent::attributeLabels(), $this->consumptionAttributeLabels(), [
             'name_inilike' => Yii::t('hipanel:server', 'Switch'),
             'rack_inilike' => Yii::t('hipanel:server', 'List of racks'),
             'rack_ilike' => Yii::t('hipanel:server', 'Rack'),

--- a/src/models/ServerSearch.php
+++ b/src/models/ServerSearch.php
@@ -16,7 +16,7 @@ use Yii;
 
 class ServerSearch extends Server
 {
-    use SearchModelTrait {
+    use ConsumptionSearchAttributes, SearchModelTrait {
         searchAttributes as defaultSearchAttributes;
         rules as defaultSearchRules;
     }
@@ -31,7 +31,7 @@ class ServerSearch extends Server
      */
     public function searchAttributes()
     {
-        return ArrayHelper::merge($this->defaultSearchAttributes(), [
+        return ArrayHelper::merge($this->defaultSearchAttributes(), $this->consumptionAttributes(), [
             'with_requests',
             'show_deleted',
             'with_discounts',
@@ -50,15 +50,12 @@ class ServerSearch extends Server
 
     public function rules()
     {
-        $rules = $this->defaultSearchRules();
-        $rules[] = [['uses_month'], 'match', 'pattern' => '/^[A-Z][a-z]{2} \d{4}$/'];
-
-        return $rules;
+        return array_merge($this->defaultSearchRules(), $this->consumptionSearchRules());
     }
 
     public function attributeLabels()
     {
-        return array_merge(parent::attributeLabels(), [
+        return array_merge(parent::attributeLabels(), $this->consumptionAttributeLabels(), [
             'wizzarded_eq' => Yii::t('hipanel:server', 'Is wizzarded'),
             'name_dc' => Yii::t('hipanel:server', 'Name or DC'),
             'hide_nic' => Yii::t('hipanel:server', 'Hide additional network interfaces'),

--- a/src/views/hub/_search.php
+++ b/src/views/hub/_search.php
@@ -1,6 +1,7 @@
-<?php
+<?php declare(strict_types=1);
 
 use hipanel\modules\client\widgets\combo\ClientCombo;
+use hipanel\modules\finance\widgets\ConsumptionRepresentationMonthPicker;
 use hipanel\widgets\AdvancedSearch;
 use hipanel\widgets\TagsInput;
 use hiqdev\combo\StaticCombo;
@@ -12,6 +13,12 @@ use hiqdev\combo\StaticCombo;
 
 
 ?>
+
+<?php if ($this->context->indexPageUiOptionsModel->representation === 'consumption') : ?>
+    <div class="col-md-4 col-sm-6 col-xs-12">
+        <?= ConsumptionRepresentationMonthPicker::widget(['model' => $search->model]) ?>
+    </div>
+<?php endif ?>
 
 <div class="col-md-4 col-sm-6 col-xs-12">
     <?= $search->field('name_inilike') ?>

--- a/src/views/hub/index.php
+++ b/src/views/hub/index.php
@@ -1,7 +1,6 @@
 <?php
 
 use hipanel\models\IndexPageUiOptions;
-use hipanel\modules\finance\widgets\ConsumptionRepresentationMonthPicker;
 use hipanel\modules\server\grid\HubGridLegend;
 use hipanel\modules\server\grid\HubGridView;
 use hipanel\modules\server\grid\HubRepresentations;
@@ -69,9 +68,6 @@ $this->registerCss('
 
     <?php $page->beginContent('representation-actions') ?>
         <?= $page->renderRepresentations($representationCollection) ?>
-        <?php if ($uiModel->representation === 'consumption') : ?>
-            <?= ConsumptionRepresentationMonthPicker::widget() ?>
-        <?php endif ?>
     <?php $page->endContent() ?>
 
     <?php $page->beginContent('bulk-actions') ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new widget, `ConsumptionRepresentationMonthPicker`, for enhanced consumption attribute selection.
	- Added functionality for managing consumption-related attributes, including validation and labeling.

- **Bug Fixes**
	- Removed unused import statements in the `Hub` class to streamline the code.

- **Refactor**
	- Updated `HubSearch` and `ServerSearch` classes to integrate new consumption attributes, improving search capabilities.

- **Chores**
	- Enforced strict type declarations in the `_search.php` view for better type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->