### PR TITLE
HP-2334: add delivery time

### DIFF
--- a/src/controllers/IrsController.php
+++ b/src/controllers/IrsController.php
@@ -38,7 +38,7 @@ class IrsController extends CrudController
                 'on beforePerform' => function (Event $event) {
                     /** @var SearchAction $action */
                     $action = $event->sender;
-                    $action->getDataProvider()->query->joinWith(['bindings']);
+                    $action->getDataProvider()->query->withBindings()->withSoftwareSettings();
                 },
             ],
         ]);

--- a/src/grid/IrsGridView.php
+++ b/src/grid/IrsGridView.php
@@ -97,7 +97,12 @@ class IrsGridView extends ServerGridView
             'delivery' => [
                 'class' => DataColumn::class,
                 'attribute' => 'delivery',
-                'value' => static fn() => '4h',
+                'label' => Yii::t('hipanel.server.irs', 'Delivery time'),
+                'value' => static fn(Irs $model): ?string => $model->softwareSettings?->delivery_time ? Yii::t(
+                    'hipanel.server.irs',
+                    '{0}h',
+                    [$model->softwareSettings?->delivery_time]
+                ) : null,
                 'filter' => false,
                 'enableSorting' => false,
                 'contentOptions' => ['style' => 'text-align: center; vertical-align: middle;'],

--- a/src/models/SoftwareSettings.php
+++ b/src/models/SoftwareSettings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Server module for HiPanel
  *
@@ -34,7 +35,7 @@ class SoftwareSettings extends \hipanel\base\Model
     public function rules()
     {
         return [
-            [['id'], 'integer'],
+            [['id', 'delivery_time'], 'integer'],
             [['virtual_switch', 'ignore_ip_mon'], 'boolean'],
             [['os', 'version', 'ip_mon_comment', 'bw_limit', 'bw_group', 'failure_contacts', 'info'], 'string'],
         ];

--- a/src/views/server/modal/softwareSettings.php
+++ b/src/views/server/modal/softwareSettings.php
@@ -1,6 +1,9 @@
 <?php
 
+/** @var Server $model */
+
 use hipanel\helpers\Url;
+use hipanel\modules\server\models\Server;
 use yii\bootstrap\ActiveForm;
 use yii\bootstrap\Html;
 
@@ -19,6 +22,9 @@ $this->params['breadcrumbs'][] = $this->title;
 
 <?= $form->field($model->softwareSettings, 'os') ?>
 <?= $form->field($model->softwareSettings, 'version') ?>
+<?= $form->field($model->softwareSettings, 'delivery_time')
+    ->input('number', ['step' => 1, 'min' => 0])
+    ->hint(Yii::t('hipanel:server', 'The unit of measurement is an hour.')) ?>
 <?= $form->field($model->softwareSettings, 'virtual_switch')->checkbox() ?>
 <?= $form->field($model->softwareSettings, 'ignore_ip_mon')->checkbox() ?>
 <?= $form->field($model->softwareSettings, 'ip_mon_comment') ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The grid view now displays delivery time dynamically with localized formatting.
  - A new numeric input field in the software settings modal lets users specify delivery time in hours, complete with enhanced validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->