### PR TITLE
HP-2456 Fix foreach() warning due to string passed instead of array on server/server/update page

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,8 +10,5 @@ tools:
 build:
     nodes:
         analysis:
-            project_setup:
-                override:
-                    - composer self-update --2
             tests:
                 override: [php-scrutinizer-run]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,5 +10,7 @@ tools:
 build:
     nodes:
         analysis:
+            before_commands:
+                - composer self-update --2
             tests:
                 override: [php-scrutinizer-run]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,7 +10,8 @@ tools:
 build:
     nodes:
         analysis:
-            before_commands:
-                - composer self-update --2
+            project_setup:
+                override:
+                    - composer self-update --2
             tests:
                 override: [php-scrutinizer-run]

--- a/src/forms/ServerForm.php
+++ b/src/forms/ServerForm.php
@@ -11,6 +11,7 @@
 namespace hipanel\modules\server\forms;
 
 use hipanel\helpers\StringHelper;
+use hipanel\modules\hosting\models\Ip;
 use hipanel\modules\server\models\Server;
 use hipanel\modules\server\validators\MacValidator;
 use Yii;
@@ -39,13 +40,34 @@ class ServerForm extends Server
      */
     public static function fromServer(Server $server): ServerForm
     {
-        $ips = self::setMainIpToBegining(ArrayHelper::getColumn($server->ips, 'ip'), $server->getAttribute('ip'));
+        $ips = [];
+        if (is_iterable($server->ips)) {
+            $ips = self::setMainIpToBegining(self::getIpsFomServer($server->ips), $server->getAttribute('ip'));
+        }
 
         return new self(array_merge(
             $server->getAttributes(),
             ['server' => $server->name, 'new_server_name' => $server->name, 'scenario' => 'update'],
             ['ips' => implode(',', $ips)]
         ));
+    }
+
+    /**
+     * @param Ip[]|string[] $ips
+     * @return string[]
+     */
+    private static function getIpsFomServer(array $ips): array
+    {
+        $items = [];
+        foreach ($ips as $ip) {
+            if ($ip instanceof Ip) {
+                $items[] = $ip->ip;
+            } else {
+                $items[] = $ip;
+            }
+        }
+
+        return $items;
     }
 
     /**

--- a/src/models/Server.php
+++ b/src/models/Server.php
@@ -32,6 +32,7 @@ use yii\base\NotSupportedException;
  *
  * @property int $id
  * @property string $name
+ * @property Ip[]|string[] $ips
  *
  * @property-read HardwareSale[] $hardwareSales
  * @property-read HardwareSettings $hardwareSettings


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4980f8c8-c253-4dd6-9762-25063ef06712)
https://sentry.hiqdev.com/organizations/hiqdev/issues/68546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of server IP addresses to support different formats and prevent errors when IP data is missing or not iterable.

- **Documentation**
  - Clarified that server IPs can be provided as either objects or strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->