### PR TITLE
HP-1581 fix 'DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated' on server/server/index page

### DIFF
--- a/src/models/HardwareSale.php
+++ b/src/models/HardwareSale.php
@@ -42,6 +42,6 @@ class HardwareSale extends \hipanel\base\Model
 
     public function saleTime(): \DateTime
     {
-        return new \DateTime($this->sale_time);
+        return new \DateTime($this->sale_time ?? 'now');
     }
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/9e5221b2-33df-4948-bad3-662fc3383665)

https://sentry.hiqdev.com/organizations/hiqdev/issues/64649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of sale time display by ensuring it always shows a valid date and time, even if sale time data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->