### PR TITLE
HP-2239: filter by last client

### DIFF
--- a/src/grid/ServerGridView.php
+++ b/src/grid/ServerGridView.php
@@ -18,6 +18,7 @@ use hipanel\grid\RefColumn;
 use hipanel\grid\XEditableColumn;
 use hipanel\helpers\StringHelper;
 use hipanel\helpers\Url;
+use hipanel\modules\client\grid\ClientColumn;
 use hipanel\modules\finance\helpers\ConsumptionConfigurator;
 use hipanel\modules\finance\helpers\ResourceHelper;
 use hipanel\modules\finance\models\Sale;
@@ -435,6 +436,10 @@ class ServerGridView extends BoxedGridView
             'hwcomment' => [
                 'filter' => false,
                 'label' => Yii::t('hipanel:server', 'Hardware Comment'),
+            ],
+            'last_client' => [
+                'class' => ClientColumn::class,
+                'attribute' => 'last_client_id',
             ],
         ], $this->getConsumptionColumns(), $columns);
     }

--- a/src/grid/ServerRepresentations.php
+++ b/src/grid/ServerRepresentations.php
@@ -27,7 +27,7 @@ class ServerRepresentations extends RepresentationCollection
                 'columns' => array_filter([
                     'checkbox',
                     $hostingExists ? 'ips' : null,
-                    'client', 'dc', 'actions', 'server', 'state',
+                    'last_client', 'dc', 'actions', 'server', 'state',
                     $user->can('order.read') && $user->can('owner-staff') ? 'order_no' : null,
                     'hwsummary',
                 ]),
@@ -37,7 +37,7 @@ class ServerRepresentations extends RepresentationCollection
                 'columns' => array_filter([
                     'checkbox',
                     'actions',
-                    'server', 'state', 'client_like', 'seller_id',
+                    'server', 'state', 'last_client', 'seller_id',
                     $hostingExists ? 'ips' : null,
                     'tariff_and_discount', 'hwsummary',
                 ]),
@@ -46,7 +46,7 @@ class ServerRepresentations extends RepresentationCollection
                 'label' => Yii::t('hipanel:server', 'hardware'),
                 'columns' => [
                     'checkbox',
-                    'rack', 'client', 'dc', 'actions', 'server', 'hwsummary', 'hwcomment',
+                    'rack', 'last_client', 'dc', 'actions', 'server', 'hwsummary', 'hwcomment',
                 ],
             ] : null,
             'summary' => $user->can('owner-staff') ? [
@@ -60,7 +60,7 @@ class ServerRepresentations extends RepresentationCollection
                 'label' => Yii::t('hipanel:server', 'manager'),
                 'columns' => array_filter([
                     'checkbox',
-                    'client_like',
+                    'last_client',
                     'rack', 'actions', 'server', 'tariff',
                     'hwsummary', 'hwcomment',
                     $hostingExists ? 'nums': null,
@@ -73,10 +73,11 @@ class ServerRepresentations extends RepresentationCollection
                     'rack',
                     'actions',
                     'server',
-                    'client_like',
+                    'last_client',
                     'tariff',
                     'monthly_fee',
-                    ...ServerGridView::$trafficColumns,
+                    ...array_keys(ServerGridView::$trafficColumns),
+                    'additional_services',
                     'type_of_sale',
                     'hwsummary',
                 ],

--- a/src/models/Hub.php
+++ b/src/models/Hub.php
@@ -43,10 +43,10 @@ class Hub extends Model implements AssignSwitchInterface, TaggableInterface
     public function rules()
     {
         return array_merge(parent::rules(), [
-            [['id', 'access_id', 'type_id', 'server_type_id', 'state_id', 'buyer_id', 'units', 'tariff_id', 'client_id'], 'integer'],
+            [['id', 'access_id', 'type_id', 'server_type_id', 'state_id', 'buyer_id', 'last_buyer_id', 'units', 'tariff_id', 'client_id', 'last_client_id'], 'integer'],
             [['tariff'], 'safe'],
             [[
-                'name', 'dc', 'mac', 'remoteid', 'note', 'ip', 'type_label', 'server_type_label', 'buyer', 'note', 'inn', 'model',
+                'name', 'dc', 'mac', 'remoteid', 'note', 'ip', 'type_label', 'server_type_label', 'buyer', 'last_buyer', 'note', 'inn', 'model',
                 'community', 'traf_server_id', 'order_no', 'ports_num', 'traf_server_id',
                 'login', 'password', 'user_login', 'user_password',
                 'vlan_server_id', 'community', 'snmp_version_id', 'digit_capacity_id', 'nic_media', 'base_port_no',
@@ -91,6 +91,8 @@ class Hub extends Model implements AssignSwitchInterface, TaggableInterface
             'tariff_id' => Yii::t('hipanel', 'Tariff'),
             'buyer_id' => Yii::t('hipanel:server:hub', 'Buyer'),
             'buyer' => Yii::t('hipanel:server:hub', 'Buyer'),
+            'last_buyer_id' => Yii::t('hipanel:server:hub', 'Final buyer'),
+            'last_buyer' => Yii::t('hipanel:server:hub', 'Final buyer'),
             'inn' => Yii::t('hipanel:server:hub', 'INN'),
             'inn_ilike' => Yii::t('hipanel:server:hub', 'INN'),
             'model' => Yii::t('hipanel:server:hub', 'Model'),
@@ -186,7 +188,7 @@ class Hub extends Model implements AssignSwitchInterface, TaggableInterface
 
     public function isServer(): bool
     {
-        return (bool)$this->server_type_id;
+        return (bool) $this->server_type_id;
     }
 
     public function isVirtualServer(): bool

--- a/src/models/Server.php
+++ b/src/models/Server.php
@@ -67,14 +67,14 @@ class Server extends Model implements AssignSwitchInterface, TaggableInterface
     {
         return [
             [['show_last_sale'], 'boolean'],
-            [['id', 'tariff_id', 'client_id', 'seller_id', 'mails_num'], 'integer'],
+            [['id', 'tariff_id', 'client_id', 'last_client_id', 'seller_id', 'mails_num'], 'integer'],
             [['osimage'], EidValidator::class],
             [['panel'], RefValidator::class],
             [['name'], 'string', 'min' => 1, 'max' => 63],
             [
                 [
                     'name', 'dc',
-                    'client', 'seller',
+                    'client', 'last_client', 'seller',
                     'os', 'panel', 'rcp',
                     'parent_tariff', 'tariff', 'tariff_note', 'discounts',
                     'request_state', 'request_state_label',

--- a/src/views/server/_search.php
+++ b/src/views/server/_search.php
@@ -61,8 +61,7 @@ use hipanel\widgets\TagsInput;
 <div class="col-md-4 col-sm-6 col-xs-12">
     <?= $search->field('ip_like') ?>
 </div>
-
-<?php if (Yii::$app->user->can('access-subclients')) : ?>
+<?php if (Yii::$app->user->canHasSubclients()) : ?>
     <div class="col-md-4 col-sm-6 col-xs-12">
         <?= $search->field('last_client_id')->widget(ClientCombo::class) ?>
     </div>

--- a/src/views/server/_search.php
+++ b/src/views/server/_search.php
@@ -64,6 +64,10 @@ use hipanel\widgets\TagsInput;
 
 <?php if (Yii::$app->user->can('access-subclients')) : ?>
     <div class="col-md-4 col-sm-6 col-xs-12">
+        <?= $search->field('last_client_id')->widget(ClientCombo::class) ?>
+    </div>
+
+    <div class="col-md-4 col-sm-6 col-xs-12">
         <?= $search->field('client_id')->widget(ClientCombo::class) ?>
     </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Last Client" column in server grid views for improved client tracking.
  - Added a search filter for "Last Client" to enhance filtering options in server searches.
- **Enhancements**
  - Updated server and hub forms to support new "Last Client" and "Final Buyer" attributes with corresponding labels.
  - Improved visibility of client-related information across multiple server representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->