### PR TITLE
HQD-142: add hub power chart sourced from PDA Alternative API

### DIFF
--- a/src/controllers/HubController.php
+++ b/src/controllers/HubController.php
@@ -39,6 +39,7 @@ use hipanel\modules\server\models\MonitoringSettings;
 use hiqdev\hiart\Collection;
 use Yii;
 use yii\base\Event;
+use yii\web\Response;
 
 class HubController extends CrudController
 {
@@ -380,5 +381,33 @@ class HubController extends CrudController
         }, 86400 * 24); // 24 days
 
         return $result;
+    }
+
+    public function actionDrawPowerChart(): string
+    {
+        $post = $this->request->post();
+        $granularity = $post['aggregation'] ?? 'month';
+        $from = $post['from'] ?? null;
+        $till = $post['till'] ?? null;
+
+        $entries = Hub::perform('hub-get-power-chart', array_filter([
+            'id'          => $post['id'],
+            'granularity' => $granularity,
+            'start_date'  => $from,
+            'end_date'    => $till,
+        ]));
+
+        $labels = [];
+        $values = [];
+        foreach ((array)$entries as $entry) {
+            $labels[] = $entry['period'];
+            $values[] = $entry['p95_value'];
+        }
+
+        return $this->renderAjax('_consumption', [
+            'labels'          => $labels,
+            'data'            => ['power' => $values],
+            'consumptionBase' => 'power',
+        ]);
     }
 }

--- a/src/controllers/HubController.php
+++ b/src/controllers/HubController.php
@@ -400,8 +400,8 @@ class HubController extends CrudController
         $labels = [];
         $values = [];
         foreach ((array)$entries as $entry) {
-            $labels[] = $entry['period'];
-            $values[] = $entry['p95_value'];
+            $labels[] = $entry['period'] ?? '';
+            $values[] = $entry['p95_value'] ?? 0;
         }
 
         return $this->renderAjax('_consumption', [

--- a/src/views/hub/view.php
+++ b/src/views/hub/view.php
@@ -8,6 +8,7 @@ use hipanel\modules\server\menus\HubDetailMenu;
 use hipanel\modules\server\models\Binding;
 use hipanel\modules\server\models\Hub;
 use hipanel\modules\server\widgets\Configuration;
+use hipanel\modules\server\widgets\PowerChartOptions;
 use hipanel\widgets\Box;
 use hipanel\widgets\MainDetails;
 use hipanel\widgets\SettingsModal;
@@ -191,6 +192,32 @@ JS
                 'mainObject' => $model,
                 'showCharts' => false,
             ]) ?>
+        </div>
+    <?php endif ?>
+    <?php if (!empty($model->remoteid) && Yii::$app->user->can('consumption.read')): ?>
+        <div class="col-md-6">
+            <?php
+            $box = Box::begin(['renderBody' => false, 'options' => ['class' => 'box-widget']]);
+            $box->beginHeader();
+            echo $box->renderTitle(Yii::t('hipanel:server', 'Power'));
+            $box->beginTools();
+            echo PowerChartOptions::widget([
+                'autoload'     => true,
+                'id'           => 'hub-power',
+                'form'         => ['action' => 'draw-power-chart'],
+                'hiddenInputs' => ['id' => ['value' => $model->id]],
+            ]);
+            $box->endTools();
+            $box->endHeader();
+            $box->beginBody();
+            echo $this->render('_consumption', [
+                'labels'          => [],
+                'data'            => [],
+                'consumptionBase' => 'power',
+            ]);
+            $box->endBody();
+            $box->end();
+            ?>
         </div>
     <?php endif ?>
     <?php if (Yii::$app->user->can('part.read')) : ?>

--- a/src/widgets/PowerChartOptions.php
+++ b/src/widgets/PowerChartOptions.php
@@ -15,7 +15,9 @@ class PowerChartOptions extends ChartOptions
     protected function buildAggregationSelect(): string
     {
         return Html::dropDownList('aggregation', 'month', [
+            'year'  => Yii::t('hipanel', 'Yearly'),
             'month' => Yii::t('hipanel', 'Monthly'),
+            'day'   => Yii::t('hipanel', 'Daily'),
         ], ['class' => 'form-control input-sm']);
     }
 }


### PR DESCRIPTION
- PowerChartOptions: extend aggregation dropdown with Yearly and Daily options alongside the existing Monthly (maps to PDA granularity param)
- HubController: add actionDrawPowerChart — reads aggregation/from/till from POST, calls Hub::perform('hub-get-power-chart'), renders the _consumption partial with p95 values
- views/hub/view.php: add a "Power" chart box for hubs that have a remoteid; uses PowerChartOptions with autoload=true pointing to draw-power-chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Power consumption chart to the Hub view, shown when the hub has a remote ID and user has consumption access.
  * Chart loads data asynchronously and supports selectable aggregation intervals: Daily, Monthly, and Yearly.
  * Initial chart renders with empty data and populates labels and values after fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->