### PR TITLE
HQD-259: Restricting to keys present in the raw request (array_intersect_key) drops those irrelevant attributes while still forwarding explicitly-cleared fields

### DIFF
--- a/src/actions/AbstractAssignHubsAction.php
+++ b/src/actions/AbstractAssignHubsAction.php
@@ -19,7 +19,7 @@ use yii\web\NotFoundHttpException;
  * @property-read string $assignableClassName
  * @property-read mixed $assignableHubs
  */
-abstract class AssignableHubs extends SmartUpdateAction
+abstract class AbstractAssignHubsAction extends SmartUpdateAction
 {
     private const array ASSIGNABLE_MAP = [
         'server' => Server::class,
@@ -57,15 +57,17 @@ abstract class AssignableHubs extends SmartUpdateAction
                 $model = clone $form;
                 $model::setModelClass($this->getAssignableClassName());
                 $model->refresh();
-                if ($model->load($hub, '')) {
-                    foreach ($model->toArray() as $key => $value) {
-                        if (str_contains($key, '_')) {
-                            $hub['hubs'][$key] = $value ?? '';
+                if ($model->load($hub, '') && $attributes = $model->toArray()) {
+                    foreach ($attributes as $key => $value) {
+//                        if (str_contains($key, '_')) { //  && !empty($value)
+                        if (str_contains($key, '_') && !empty($value)) {
+                            $hub['hubs'][$key] = $value;
                             unset($hub[$key]);
                         }
                     }
                 }
             }
+            $a = 1;
             $this->collection->load($hubs);
         };
         parent::init();

--- a/src/actions/AbstractAssignHubsAction.php
+++ b/src/actions/AbstractAssignHubsAction.php
@@ -57,17 +57,15 @@ abstract class AbstractAssignHubsAction extends SmartUpdateAction
                 $model = clone $form;
                 $model::setModelClass($this->getAssignableClassName());
                 $model->refresh();
-                if ($model->load($hub, '') && $attributes = $model->toArray()) {
+                if ($model->load($hub, '') && $attributes = array_intersect_key($model->toArray(), $hub)) {
                     foreach ($attributes as $key => $value) {
-//                        if (str_contains($key, '_')) { //  && !empty($value)
-                        if (str_contains($key, '_') && !empty($value)) {
+                        if (str_contains($key, '_')) {
                             $hub['hubs'][$key] = $value;
                             unset($hub[$key]);
                         }
                     }
                 }
             }
-            $a = 1;
             $this->collection->load($hubs);
         };
         parent::init();

--- a/src/actions/AssignHubsAction.php
+++ b/src/actions/AssignHubsAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace hipanel\modules\server\actions;
 
-class AssignHubsAction extends AssignableHubs
+class AssignHubsAction extends AbstractAssignHubsAction
 {
     protected function collectFromRequest(): array
     {

--- a/src/actions/BulkSetRackNoAction.php
+++ b/src/actions/BulkSetRackNoAction.php
@@ -7,7 +7,7 @@ namespace hipanel\modules\server\actions;
 
 use yii\helpers\ArrayHelper;
 
-class BulkSetRackNoAction extends AssignableHubs
+class BulkSetRackNoAction extends AbstractAssignHubsAction
 {
     protected function collectFromRequest(): array
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved hub assignment handling to process only relevant model attributes.
  * Preserved existing filtering and assignment behavior while removing unnecessary default value substitution.
  * Updated hub assignment actions to use a shared, consistently named foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->